### PR TITLE
Update Camera2D limiting

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -170,19 +170,33 @@ Transform2D Camera2D::get_camera_transform() {
 		Rect2 screen_rect(-screen_offset + camera_pos, screen_size * zoom_scale);
 
 		if (limit_smoothing_enabled) {
+			// Apply horizontal limiting.
 			if (screen_rect.position.x < limit[SIDE_LEFT]) {
-				camera_pos.x -= screen_rect.position.x - limit[SIDE_LEFT];
+				if (screen_rect.position.x + screen_rect.size.x > limit[SIDE_RIGHT]) {
+					// Split the limit difference horizontally.
+					camera_pos.x -= (screen_rect.position.x + screen_rect.size.x - limit[SIDE_RIGHT] + screen_rect.position.x - limit[SIDE_LEFT]) / 2;
+				} else {
+					// Only apply left limit.
+					camera_pos.x -= screen_rect.position.x - limit[SIDE_LEFT];
+				}
 			}
-
-			if (screen_rect.position.x + screen_rect.size.x > limit[SIDE_RIGHT]) {
+			else if (screen_rect.position.x + screen_rect.size.x > limit[SIDE_RIGHT]) {
+				// Only apply the right limit.
 				camera_pos.x -= screen_rect.position.x + screen_rect.size.x - limit[SIDE_RIGHT];
 			}
 
+			// Apply vertical limiting.
 			if (screen_rect.position.y + screen_rect.size.y > limit[SIDE_BOTTOM]) {
-				camera_pos.y -= screen_rect.position.y + screen_rect.size.y - limit[SIDE_BOTTOM];
+				if (screen_rect.position.y < limit[SIDE_TOP]) {
+					// Split the limit difference vertically.
+					camera_pos.y -= (screen_rect.position.y + screen_rect.size.y - limit[SIDE_BOTTOM] + screen_rect.position.y - limit[SIDE_TOP]) / 2;
+				} else {
+					// Only apply the bottom limit.
+					camera_pos.y -= screen_rect.position.y + screen_rect.size.y - limit[SIDE_BOTTOM];
+				}
 			}
-
-			if (screen_rect.position.y < limit[SIDE_TOP]) {
+			else if (screen_rect.position.y < limit[SIDE_TOP]) {
+				// Only apply the top limit.
 				camera_pos.y -= screen_rect.position.y - limit[SIDE_TOP];
 			}
 		}


### PR DESCRIPTION
Update Camera2D limiting to support the case where the limits are smaller than the screen rect.

In this case, it makes the most sense to center the view in the limits rather than allowing the top/right limits to dominate simply because they were applied last.